### PR TITLE
Add JSON template for subdomain and DNS record management

### DIFF
--- a/domains/drivemc.json
+++ b/domains/drivemc.json
@@ -1,0 +1,244 @@
+{   "title": "Title of the website",
+	"description": "Template to register each subdomain for complete.template.creepers.sbs/cloud/pro/lol with multiple records + mutiple spare records for each tld. Delete the text in the () as it's just to explain.",
+	"domain": "creepers.sbs",
+	"subdomain": "complete.template (remember that this has to be the exact same as the file name and it's the actual subdomain you will use for each tld)",
+	"country_code": "none",
+	"owner": {
+		"github_user": "https://github.com/username",
+		"email": "very_cool_email@anywebsite.tld",
+		"discord": "@this.is.a.discord.username"
+	},
+	"record": {
+		"spare_record": [
+			"mc (mc.complete.template.creepers.sbs)",
+			"A / AAAA / CNAME / MX / etc...",
+            "target"
+		],
+        "spare_record_2": [
+			"smth._domainkey (smth._domainkey.complete.template.creepers.sbs)",
+			"A / AAAA / CNAME / MX / etc...",
+            "target"
+		],
+        "spare_record_3": [
+			"docs (docs.complete.template.creepers.sbs)",
+			"A / AAAA / CNAME / MX / etc...",
+            "target"
+		],
+		"A": [
+			"1.1.1.1",
+			"1.0.0.1"
+		],
+		"AAAA": [
+			"::1",
+			"::2"
+		],
+		"CNAME": 
+            "anywebsite.tld",
+		"MX": [
+			"mx1.anywebsite.tld",
+			"mx2.anywebsite.tld"
+		],
+        "NS": [
+			"ns1.anywebsite.tld",
+			"ns2.anywebsite.tld",
+            "ns3.anywebsite.tld",
+            "ns4.anywebsite.tld",
+            "ns5.anywebsite.tld"
+		],
+		"TXT": [
+			"thi_is_an_example_verification=012345678910"
+		],
+		"SRV": [
+			{
+				"content": "_a_srv.record",
+				"priority": 10,
+				"weight": 60,
+				"ttl": "auto",
+				"port": 5060,
+				"target": "mcsrv.anydomain.tld"
+			},
+			{
+				"content": "_a_srv.record",
+				"priority": 20,
+				"weight": 10,
+				"ttl": "auto",
+				"port": 5061,
+				"target": "srv.anydomain.tld"
+			}
+		]
+	},
+	"proxy": "false/true",
+
+
+    
+    "domain_2": "creepers.cloud",
+	"record_2": {
+		"spare_record": [
+			"anotherone (anotherone.complete.template.creepers.cloud)",
+			"A / AAAA / CNAME / MX / etc...",
+            "target"
+		],
+        "spare_record_2": [
+			"yetanotherone (yetanotherone.complete.template.creepers.cloud)",
+			"A / AAAA / CNAME / MX / etc...",
+            "target"
+		],
+		"A": [
+			"1.1.1.1",
+			"1.0.0.1"
+		],
+		"AAAA": [
+			"::1",
+			"::2"
+		],
+		"CNAME": "anywebsite.tld",
+		"MX": [
+			"mx1.anywebsite.tld",
+			"mx2.anywebsite.tld"
+		],
+        "NS": [
+			"ns1.anywebsite.tld",
+			"ns2.anywebsite.tld",
+            "ns3.anywebsite.tld",
+            "ns4.anywebsite.tld",
+            "ns5.anywebsite.tld"
+		],
+		"TXT": [
+			"thi_is_an_example_verification=012345678910"
+		],
+		"SRV": [
+			{
+				"content": "_a_srv.record",
+				"priority": 10,
+				"weight": 60,
+				"ttl": "auto",
+				"port": 5060,
+				"target": "mcsrv.anydomain.tld"
+			},
+			{
+				"content": "_a_srv.record",
+				"priority": 20,
+				"weight": 10,
+				"ttl": "auto",
+				"port": 5061,
+				"target": "srv.anydomain.tld"
+			}
+		]
+	},
+	"proxy_2": "false/true",
+
+
+
+	"domain_3": "creepers.pro",
+	"record_3": {
+		"spare_record": [
+			"anotherone (anotherone.complete.template.creepers.pro)",
+			"A / AAAA / CNAME / MX / etc...",
+            "target"
+		],
+        "spare_record_2": [
+			"yetanotherone (yetanotherone.complete.template.creepers.pro)",
+			"A / AAAA / CNAME / MX / etc...",
+            "target"
+		],
+		"A": [
+			"1.1.1.1",
+			"1.0.0.1"
+		],
+		"AAAA": [
+			"::1",
+			"::2"
+		],
+		"CNAME": "anywebsite.tld",
+		"MX": [
+			"mx1.anywebsite.tld",
+			"mx2.anywebsite.tld"
+		],
+        "NS": [
+			"ns1.anywebsite.tld",
+			"ns2.anywebsite.tld",
+            "ns3.anywebsite.tld",
+            "ns4.anywebsite.tld",
+            "ns5.anywebsite.tld"
+		],
+		"TXT": [
+			"thi_is_an_example_verification=012345678910"
+		],
+		"SRV": [
+			{
+				"content": "_a_srv.record",
+				"priority": 10,
+				"weight": 60,
+				"ttl": "auto",
+				"port": 5060,
+				"target": "mcsrv.anydomain.tld"
+			},
+			{
+				"content": "_a_srv.record",
+				"priority": 20,
+				"weight": 10,
+				"ttl": "auto",
+				"port": 5061,
+				"target": "srv.anydomain.tld"
+			}
+		]
+	},
+	"proxy_3": "false/true",
+
+
+	"domain_4": "creepers.lol",
+	"record_4": {
+		"spare_record": [
+			"anotherone (anotherone.complete.template.creepers.lol)",
+			"A / AAAA / CNAME / MX / etc...",
+            "target"
+		],
+        "spare_record_2": [
+			"yetanotherone (yetanotherone.complete.template.creepers.lol)",
+			"A / AAAA / CNAME / MX / etc...",
+            "target"
+		],
+		"A": [
+			"1.1.1.1",
+			"1.0.0.1"
+		],
+		"AAAA": [
+			"::1",
+			"::2"
+		],
+		"CNAME": "anywebsite.tld",
+		"MX": [
+			"mx1.anywebsite.tld",
+			"mx2.anywebsite.tld"
+		],
+        "NS": [
+			"ns1.anywebsite.tld",
+			"ns2.anywebsite.tld",
+            "ns3.anywebsite.tld",
+            "ns4.anywebsite.tld",
+            "ns5.anywebsite.tld"
+		],
+		"TXT": [
+			"thi_is_an_example_verification=012345678910"
+		],
+		"SRV": [
+			{
+				"content": "_a_srv.record",
+				"priority": 10,
+				"weight": 60,
+				"ttl": "auto",
+				"port": 5060,
+				"target": "mcsrv.anydomain.tld"
+			},
+			{
+				"content": "_a_srv.record",
+				"priority": 20,
+				"weight": 10,
+				"ttl": "auto",
+				"port": 5061,
+				"target": "srv.anydomain.tld"
+			}
+		]
+	},
+	"proxy_4": "false/true"
+}


### PR DESCRIPTION
Added a JSON template for managing subdomains and DNS records for multiple domains including creepers.sbs, creepers.cloud, creepers.pro, and creepers.lol.


# 📌 Type of Pull Request

*(Please check one by putting and "x" betwenn the [ ] (Delete the space while putting the x))* 

- [ ] New Subdomain Request
- [ ] Update / Change DNS Records
- [ ] Change NS records
- [ ] Other (explain below)

---

# 👤 Your Information

- **GitHub Username (required)**:  
- **Email Address (required)**:  
- Discord Username (optional): 
---

# 🌐 Subdomain Request Details

- **Requested Subdomain** (e.g., `example.creepers.tld`):  
- **TLD** (`.sbs` / `.cloud` / `.pro` / `.lol`):  
- **Custom NS Records** (if any):  

---

# 📝 Description

Please provide a detailed description of your request (required):

- Purpose of the subdomain  
- Any existing infrastructure or website associated  
- Any special configuration or requirements  

---

# ✅ Confirmation

By submitting this Pull Request, I confirm that:

- [ ] I have read and agree to the [Terms of Service](https://github.com/creepersbs/register/blob/main/TERMS.md)  
- [ ] I understand that I am solely responsible for DNS configuration and content hosted on this subdomain  
- [ ] All information provided is accurate and truthful  

*(Please check one by putting and "x" betwenn the [ ] again)*

---

> ⚠ Note for reviewers:  
> Check that the request follows the template and does not violate restricted or reserved subdomain rules.

