### PR TITLE
Create evolvemc.json

### DIFF
--- a/domains/evolvemc.json
+++ b/domains/evolvemc.json
@@ -1,0 +1,94 @@
+{
+  "title": "EvolveMC",
+  "description": "Official Minecraft server for EvolveMC community",
+  "domain": "creepers.sbs",
+  "subdomain": "evolvemc",
+  "country_code": "none",
+  "owner": {
+    "github_user": "https://github.com/gmoilu951-cyber",
+    "email": "Itsnil.offical@gmail.com",
+    "discord": "@nilop4"
+  },
+  "record": {
+    "spare_record": [
+      "play",
+      "CNAME",
+      "arrow.playwithbao.com"
+    ],
+    "CNAME": "arrow.playwithbao.com",
+    "SRV": [
+      {
+        "content": "_minecraft._tcp",
+        "priority": 0,
+        "weight": 5,
+        "ttl": "auto",
+        "port": 53738,
+        "target": "arrow.playwithbao.com"
+      }
+    ]
+  },
+  "proxy": "false",
+
+  "domain_2": "creepers.cloud",
+  "record_2": {
+    "spare_record": [
+      "play",
+      "CNAME",
+      "arrow.playwithbao.com"
+    ],
+    "CNAME": "arrow.playwithbao.com",
+    "SRV": [
+      {
+        "content": "_minecraft._tcp",
+        "priority": 0,
+        "weight": 5,
+        "ttl": "auto",
+        "port": 53738,
+        "target": "arrow.playwithbao.com"
+      }
+    ]
+  },
+  "proxy_2": "false",
+
+  "domain_3": "creepers.pro",
+  "record_3": {
+    "spare_record": [
+      "play",
+      "CNAME",
+      "arrow.playwithbao.com"
+    ],
+    "CNAME": "arrow.playwithbao.com",
+    "SRV": [
+      {
+        "content": "_minecraft._tcp",
+        "priority": 0,
+        "weight": 5,
+        "ttl": "auto",
+        "port": 53738,
+        "target": "arrow.playwithbao.com"
+      }
+    ]
+  },
+  "proxy_3": "false",
+
+  "domain_4": "creepers.lol",
+  "record_4": {
+    "spare_record": [
+      "play",
+      "CNAME",
+      "arrow.playwithbao.com"
+    ],
+    "CNAME": "arrow.playwithbao.com",
+    "SRV": [
+      {
+        "content": "_minecraft._tcp",
+        "priority": 0,
+        "weight": 5,
+        "ttl": "auto",
+        "port": 53738,
+        "target": "arrow.playwithbao.com"
+      }
+    ]
+  },
+  "proxy_4": "false"
+}


### PR DESCRIPTION
# 📌 Type of Pull Request

*(Please check one by putting and "x" betwenn the [ ] (Delete the space while putting the x))* 

- [X] New Subdomain Request
- [ ] Update / Change DNS Records
- [ ] Change NS records
- [ ] Other (explain below)

---

# 👤 Your Information

- **GitHub Username (required)**:  gmoilu951-cyber
- **Email Address (required)**:  itsnil.offical@gmail.com
- Discord Username (optional): @nilop4
--- 

# 🌐 Subdomain Request Details

- **Requested Subdomain** (e.g., `example.creepers.tld`):  evolvemc.creepers.tld
- **TLD** (`.sbs` / `.cloud` / `.pro` / `.lol`): `.sbs` / `.cloud` / `.pro` / `.lol`
- **Custom NS Records** (if any):  

--- 

# 📝 Description

Please provide a detailed description of your request (required):

- Purpose of the subdomain  
- Any existing infrastructure or website associated  
- Any special configuration or requirements  

Purpose of the subdomain:
The subdomain will be used as the main address for my Minecraft server so players can join using a clean and easy-to-remember domain instead of a long IP and port.
Existing infrastructure or website:
The server is already hosted and accessible via arrow.playwithbao.com:53738. There is currently no website attached, but I may add one later.
Special configuration or requirements:
The setup requires a CNAME record pointing to arrow.playwithbao.com and an SRV record to handle the custom port (53738), allowing players to connect without specifying the port. No additional services like email or nameservers are needed at this time.
--- 

# ✅ Confirmation

By submitting this Pull Request, I confirm that:

- [X] I have read and agree to the [Terms of Service](https://github.com/creepersbs/register/blob/main/TERMS.md)  
- [X] I understand that I am solely responsible for DNS configuration and content hosted on this subdomain  
- [X] All information provided is accurate and truthful  

*(Please check one by putting and "x" betwenn the [ ] again)*

---

> ⚠ Note for reviewers:  
> Check that the request follows the template and does not violate restricted or reserved subdomain rules.

