### PR TITLE
Add _vercel.creepers.lol TXT for Vercel ownership verification

### DIFF
--- a/domains/_vercel.json
+++ b/domains/_vercel.json
@@ -1,0 +1,17 @@
+{
+  "title": "Astra Vercel verification (temporary)",
+  "description": "TXT record required by Vercel to verify ownership of astra.creepers.lol (domain linked to another Vercel account). Temporary - can be removed after verification completes.",
+  "domain": "creepers.lol",
+  "subdomain": "_vercel",
+  "country_code": "none",
+  "owner": {
+    "github_user": "https://github.com/Olgy1",
+    "email": "gls.kyle@icloud.com"
+  },
+  "record": {
+    "TXT": [
+      "vc-domain-verify=astra.creepers.lol,4846ab6f85895be39876"
+    ]
+  },
+  "proxy": "false"
+}


### PR DESCRIPTION
# 📌 Type of Pull Request

- [x] New Subdomain Request
- [ ] Update / Change DNS Records
- [ ] Change NS records
- [ ] Other (explain below)

---

# 👤 Your Information

- **GitHub Username (required)**: Olgy1
- **Email Address (required)**: gls.kyle@icloud.com
- Discord Username (optional): 

---

# 🌐 Subdomain Request Details

- **Requested Subdomain** (e.g., `example.creepers.tld`): `_vercel.creepers.lol`
- **TLD** (`.sbs` / `.cloud` / `.pro` / `.lol`): `.lol`
- **Custom NS Records** (if any): None

---

# 📝 Description

Please provide a detailed description of your request (required):

- Purpose of the subdomain: Vercel is asking for a TXT record at `_vercel.creepers.lol` to verify ownership of `astra.creepers.lol`, which is linked to another Vercel account ("This domain is linked to another Vercel account. To use it with this project, add a TXT record at _vercel.creepers.lol to verify ownership. You can remove it after verification completes."). The `spare_record` in my previous PR (`astra.creepers.lol`, #130) landed at `_vercel.astra.creepers.lol`, not `_vercel.creepers.lol`.
- This is a **temporary** verification record: it can be removed once Vercel completes the domain verification.
- Any existing infrastructure or website associated: `astra.creepers.lol` (merged in #130) points to Vercel via CNAME `c43aedc1d8c42622.vercel-dns-017.com`, with a 308 redirect to `astraai.is-cool.dev`.

@giocoliere hello! Following up on #130: Vercel requires this TXT at `_vercel.creepers.lol` (zone level) to complete verification. If registering `_vercel` as a subdomain is not the right approach, could the team add this single TXT record to the `creepers.lol` zone directly? Thank you!

---

# ✅ Confirmation

By submitting this Pull Request, I confirm that:

- [x] I have read and agree to the [Terms of Service](https://github.com/creepersbs/register/blob/main/TERMS.md)
- [x] I understand that I am solely responsible for DNS configuration and content hosted on this subdomain
- [x] All information provided is accurate and truthful
