### PR TITLE
Register neobrowser.creepers.sbs

### DIFF
--- a/domains/neobrowser.json
+++ b/domains/neobrowser.json
@@ -1,0 +1,20 @@
+{
+    "title": "NeoBrowser",
+    "description": "Open-source MCP server that drives real Google Chrome with real logged-in sessions for AI agents.",
+    "domain": "creepers.sbs",
+    "subdomain": "neobrowser",
+    "country_code": "none",
+    "owner": {
+        "github_user": "https://github.com/pitiflautico",
+        "email": "pitiflautico3@gmail.com"
+    },
+    "record": {
+        "A": [
+            "185.199.108.153",
+            "185.199.109.153",
+            "185.199.110.153",
+            "185.199.111.153"
+        ]
+    },
+    "proxy": "false"
+}


### PR DESCRIPTION
Registering neobrowser.creepers.sbs for an open-source MCP browser-automation project. A records point to GitHub Pages.