### PR TITLE
register dihagent.creepers.pro (Railway dashboard)

### DIFF
--- a/domains/dihagent.json
+++ b/domains/dihagent.json
@@ -1,0 +1,15 @@
+{
+  "title": "DihAgent",
+  "description": "DihSpeed trading-agent dashboard (paper trading bot), hosted on Railway.",
+  "domain": "creepers.pro",
+  "subdomain": "dihagent",
+  "country_code": "none",
+  "owner": {
+    "github_user": "https://github.com/onlydeployyyessss",
+    "email": "onlydeployyyessss@users.noreply.github.com"
+  },
+  "record": {
+    "CNAME": "dihspeed-production.up.railway.app"
+  },
+  "proxy": "false"
+}


### PR DESCRIPTION
DihSpeed is a personal paper-trading agent (prediction-market simulator, no real money) hosted on Railway. Its dashboard needs a stable, memorable address.

- Target verified reachable: `https://dihspeed-production.up.railway.app` returns HTTP 200 right now.
- Repo: https://github.com/onlydeployyyessss/dihspeed-agent
- No NS records needed, no wildcard — a single CNAME subdomain.
