### PR TITLE
Register b2r.creepers.pro and b2r.creepers.lol

### DIFF
--- a/domains/b2r.json
+++ b/domains/b2r.json
@@ -1,0 +1,35 @@
+{
+  "title": "B2R Minecraft Server",
+  "description": "Minecraft server (ReIndev). b2r.creepers.pro points to the direct address, b2r.creepers.lol points to the tunnelled one.",
+  "domain": "creepers.pro",
+  "subdomain": "b2r",
+  "country_code": "none",
+  "owner": {
+    "github_user": "https://github.com/FLEXIY0",
+    "email": "fleeeeexiy@gmail.com"
+  },
+  "record": {
+    "A": [
+      "109.194.3.119"
+    ]
+  },
+  "proxy": "false",
+
+  "domain_2": "creepers.lol",
+  "record_2": {
+    "A": [
+      "176.223.133.253"
+    ],
+    "SRV": [
+      {
+        "content": "_minecraft._tcp",
+        "priority": 10,
+        "weight": 60,
+        "ttl": "auto",
+        "port": 33642,
+        "target": "b2r.creepers.lol"
+      }
+    ]
+  },
+  "proxy_2": "false"
+}


### PR DESCRIPTION
# 📌 Type of Pull Request

- [x] New Subdomain Request
- [ ] Update / Change DNS Records
- [ ] Change NS records
- [ ] Other (explain below)

---

# 👤 Your Information

- **GitHub Username (required)**: FLEXIY0
- **Email Address (required)**: fleeeeexiy@gmail.com

---

# 🌐 Subdomain Request Details

- **Requested Subdomain**: `b2r.creepers.pro` and `b2r.creepers.lol`
- **TLD**: `.pro` + `.lol` (one name, two TLDs, in a single `domains/b2r.json`)
- **Custom NS Records**: none

---

# 📝 Description

**Purpose.** The subdomain is for a small public Minecraft server (ReIndev 2.9_03 + FoxLoader),
so players can join by name instead of memorising a bare IP address.

**Existing infrastructure.** The server is already up and running. It is reachable over two
separate paths, which is why one name is requested on two TLDs:

- `b2r.creepers.pro` → `A 109.194.3.119` — the direct address of the machine, default port `25565`.
- `b2r.creepers.lol` → `A 176.223.133.253` — the same server behind an frp TCP tunnel, whose public
  port is `33642`. Because of the non-default port this one also carries an
  `_minecraft._tcp` SRV record pointing at `b2r.creepers.lol:33642`.

**Special configuration.** `proxy` is `false` on both, since the Cloudflare proxy does not pass
raw Minecraft TCP traffic. No mail, no website, no wildcard records.

The file follows `domains/complete.template.json` for the multi-TLD layout, and the JSON has been
validated. `b2r` does not appear in `domains/reserved/list.json` or `domains/blacklisted/list.json`.

---

# ✅ Confirmation

By submitting this Pull Request, I confirm that:

- [x] I have read and agree to the [Terms of Service](https://github.com/creepersbs/register/blob/main/TERMS.md)
- [x] I understand that I am solely responsible for DNS configuration and content hosted on this subdomain
- [x] All information provided is accurate and truthful
